### PR TITLE
Add exit task by exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ After run this line, user will get following output.
 { "name": "plugin_3", "repository url": "http://example.com/repo3" }
 ```
 
+# Note
+
+If your function, which called by `zcl`, returned `0` as exit code, `zcl` will
+stop at that point without any error message.
+
 # License
 
 This project is distributed under MIT License. See `LICENSE` .

--- a/zcl
+++ b/zcl
@@ -125,6 +125,11 @@ function _zcl::main()
 
       # Run task
       ${task_function} ${mapped_args}
+      local -i exit_code=$?
+      if [[ ${exit_code} != 0 ]]
+      then
+        return ${exit_code}
+      fi
     done
 
   return 0


### PR DESCRIPTION
With this modification, `zcl` will exit when given task returns NOT `0` as exit code.